### PR TITLE
Methadone post fix

### DIFF
--- a/_posts/2011-12-19-methadone-the-awesome-cli-library.markdown
+++ b/_posts/2011-12-19-methadone-the-awesome-cli-library.markdown
@@ -44,7 +44,7 @@ require 'optparse'
 options = {}
 
 parser = OptionParser.new do |opts|
-  opts.banner 'My awesome app'
+  opts.banner = 'My awesome app'
   
   opts.on("-u USERNAME","--username","The username") do |user|
     options[:username] = user

--- a/_posts/2011-12-19-methadone-the-awesome-cli-library.markdown
+++ b/_posts/2011-12-19-methadone-the-awesome-cli-library.markdown
@@ -64,6 +64,7 @@ def some_helper_method
 end
 
 def some_other_helper_method
+end
 
 puts "Starting program" if options[:verbose]
 


### PR DESCRIPTION
Just some minor fixes so the example be copied/pasted and run :).

```
➜  somecli ./app
./app:31: syntax error, unexpected end-of-input, expecting keyword_end
➜  somecli ./app
/Users/max/.rbenv/versions/2.3.1/lib/ruby/2.3.0/optparse.rb:1136:in `banner': wrong number of arguments (given 1, expected 0) (ArgumentError)
    from ./app:8:in `block in <main>'
    from /Users/max/.rbenv/versions/2.3.1/lib/ruby/2.3.0/optparse.rb:1061:in `initialize'
    from ./app:7:in `new'
    from ./app:7:in `<main>'
```

after fixes

```
➜  somecli ./app
➜  somecli ./app -h
My awesome app
    -u, --username USERNAME          The username
    -v, --verbose                    Be verbose
```
